### PR TITLE
max_dbs_open_warn environment variable was not used

### DIFF
--- a/couchdb_
+++ b/couchdb_
@@ -523,7 +523,7 @@ EOF
             my $warn_rate = 0;
             my $crit_rate = 0;
             if (exists($ENV{'max_dbs_open_warn'})) {
-                $crit_rate = int($ENV{'max_dbs_open_warn'});
+                $warn_rate = int($ENV{'max_dbs_open_warn'});
             }
             if (exists($ENV{'max_dbs_open_crit'})) {
                 $crit_rate = int($ENV{'max_dbs_open_crit'});


### PR DESCRIPTION
max_dbs_open_warn environment variable was not used beacause it was read into crit_rate instead of warn_rate. Therefore default 90% was used in any case.
